### PR TITLE
Reduce workers to 500 to enhance result reliablity

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ import (
 
 var debug bool
 var timeoutMS int = 2000
-var parallelism int = 1000
+var parallelism int = 500
 var portSelection string
 var scanType = "stealth"
 var hideUnavailableHosts bool


### PR DESCRIPTION
after quite a bit of testing, it seems that the default 1000 workers give wildly unreliable results, 250 was slower than nmap and 500 was the sweet spot, giving very consistent results while staying faster than nmap.

This thing rocks by the way, really good code, love it.